### PR TITLE
Implement an interface for the memory helper class.

### DIFF
--- a/sources.f
+++ b/sources.f
@@ -12,5 +12,4 @@ src/registers.sv
 src/scheduler.sv
 test/helpers/logger.sv
 test/helpers/memory.sv
-test/helpers/setup.sv
 test/test_matadd.sv

--- a/sources.f
+++ b/sources.f
@@ -12,4 +12,5 @@ src/registers.sv
 src/scheduler.sv
 test/helpers/logger.sv
 test/helpers/memory.sv
+test/helpers/memoryif.sv
 test/test_matadd.sv

--- a/src/core.sv
+++ b/src/core.sv
@@ -33,7 +33,7 @@ module core #(
     output logic [THREADS_PER_BLOCK-1:0] data_mem_read_valid,
     output logic [DATA_MEM_ADDR_BITS-1:0] data_mem_read_address [THREADS_PER_BLOCK-1:0],
     input logic [THREADS_PER_BLOCK-1:0] data_mem_read_ready,
-    input logic [DATA_MEM_DATA_BITS-1:0] data_mem_read_data [THREADS_PER_BLOCK-1:0],
+    input wire [DATA_MEM_DATA_BITS-1:0] data_mem_read_data [THREADS_PER_BLOCK-1:0],
     output logic [THREADS_PER_BLOCK-1:0] data_mem_write_valid,
     output logic [DATA_MEM_ADDR_BITS-1:0] data_mem_write_address [THREADS_PER_BLOCK-1:0],
     output logic [DATA_MEM_DATA_BITS-1:0] data_mem_write_data [THREADS_PER_BLOCK-1:0],

--- a/test/helpers/memory.sv
+++ b/test/helpers/memory.sv
@@ -32,24 +32,28 @@ class Memory #(
     // Simulates one clock cycle of memory activity
     task run();
         for (int i = 0; i < CHANNELS; i++) begin
-            // READ handling
-            if (mem.read_valid[i]) begin
+            // READ handling (pulse read_ready)
+            if (mem.read_valid[i] && !mem.read_ready[i]) begin
                 mem.read_data[i]  = memory[mem.read_address[i]];
                 mem.read_ready[i] = 1;
+                $display("[%s] Read ch%0d addr=%0d -> data=%0d",
+                        name, i, mem.read_address[i], mem.read_data[i]);
             end else begin
-                mem.read_data[i]  = '0;
-                mem.read_ready[i] = 0;
+                mem.read_ready[i] = 0; // Deassert after one cycle
             end
 
-            // WRITE handling
-            if (mem.write_valid[i]) begin
+            // WRITE handling (pulse write_ready)
+            if (mem.write_valid[i] && !mem.write_ready[i]) begin
                 memory[mem.write_address[i]] = mem.write_data[i];
                 mem.write_ready[i] = 1;
+                $display("[%s] Write ch%0d addr=%0d <- data=%0d",
+                        name, i, mem.write_address[i], mem.write_data[i]);
             end else begin
-                mem.write_ready[i] = 0;
+                mem.write_ready[i] = 0; // Deassert after one cycle
             end
         end
     endtask
+
 
     // Manual memory write (bypasses interface)
     task write(addr_t address, data_t data);
@@ -72,3 +76,4 @@ class Memory #(
         $display("========================\n");
     endtask
 endclass
+

--- a/test/helpers/memory.sv
+++ b/test/helpers/memory.sv
@@ -1,98 +1,74 @@
-// DUT Signals
-// Memory read signals
-// - Read valid
-// - Read ready
-// - Read address
-// - Read data
+class Memory #(
+    parameter int ADDR_BITS = 8,
+    parameter int DATA_BITS = 16,
+    parameter int CHANNELS  = 1
+);
+    string name;
 
-// Memory write signals
-// - Write valid
-// - Write ready
-// - Write address
-// - Write data
+    typedef logic [ADDR_BITS-1:0] addr_t;
+    typedef logic [DATA_BITS-1:0] data_t;
+    data_t memory [0:2**ADDR_BITS-1];
 
-// Memory class
-class Memory #(parameter int ADDR_BITS = 8, 
-                parameter int DATA_BITS = 16, 
-                parameter int CHANNELS = 1);
+    // This must match the declared port name exactly
+    virtual mem_if #(
+        .ADDR_BITS(ADDR_BITS),
+        .DATA_BITS(DATA_BITS),
+        .CHANNELS(CHANNELS)
+    ) mem;
 
-string name;
+    // Constructor
+    function new(string name__, virtual mem_if #(
+        .ADDR_BITS(ADDR_BITS),
+        .DATA_BITS(DATA_BITS),
+        .CHANNELS(CHANNELS)
+    ) mem__);
+        this.name = name__;
+        this.mem  = mem__;
 
-logic [CHANNELS-1:0] mem_read_valid;
-logic [ADDR_BITS-1:0] mem_read_address [CHANNELS];
-logic [DATA_BITS-1:0] mem_read_data [CHANNELS];
-logic [CHANNELS-1:0] mem_read_ready;
+        // Initialize memory contents to zero
+        foreach (memory[i]) memory[i] = '0;
+    endfunction
 
-logic [CHANNELS-1:0] mem_write_valid;
-logic [ADDR_BITS-1:0] mem_write_address [CHANNELS];
-logic [DATA_BITS-1:0] mem_write_data [CHANNELS];
-logic [CHANNELS-1:0] mem_write_ready;
+    // Simulates one clock cycle of memory activity
+    task run();
+        for (int i = 0; i < CHANNELS; i++) begin
+            // READ handling
+            if (mem.read_valid[i]) begin
+                mem.read_data[i]  = memory[mem.read_address[i]];
+                mem.read_ready[i] = 1;
+            end else begin
+                mem.read_data[i]  = '0;
+                mem.read_ready[i] = 0;
+            end
 
-typedef logic [ADDR_BITS-1:0] addr_t;
-typedef logic [DATA_BITS-1:0] data_t;
-data_t memory [0:2**ADDR_BITS-1];
-
-function new(string name__);
-    this.name = name__;
-    // Initialize memory to zero
-    foreach (memory[i]) memory[i] = '0;
-endfunction
-
-// Run function:
-// Run function:
-task run();
-    data_t read_data[CHANNELS];
-    bit read_ready[CHANNELS];
-    bit write_ready[CHANNELS];
-
-    // READ logic
-    for (int i = 0; i < CHANNELS; i++) begin
-        if (mem_read_valid[i]) begin
-            read_data[i]  = memory[mem_read_address[i]];
-            read_ready[i] = 1;
-        end else begin
-            read_data[i]  = '0;
-            read_ready[i] = 0;
+            // WRITE handling
+            if (mem.write_valid[i]) begin
+                memory[mem.write_address[i]] = mem.write_data[i];
+                mem.write_ready[i] = 1;
+            end else begin
+                mem.write_ready[i] = 0;
+            end
         end
-        mem_read_data[i]  = read_data[i];
-        mem_read_ready[i] = read_ready[i];
-    end
+    endtask
 
-    // WRITE logic
-    for (int i = 0; i < CHANNELS; i++) begin
-        if (mem_write_valid[i]) begin
-            memory[mem_write_address[i]] = mem_write_data[i];
-            write_ready[i] = 1;
-        end else begin
-            write_ready[i] = 0;
+    // Manual memory write (bypasses interface)
+    task write(addr_t address, data_t data);
+        if (address < (1 << ADDR_BITS)) begin
+            memory[address] = data;
         end
-        mem_write_ready[i] = write_ready[i];
-    end
-endtask
+    endtask
 
+    // Load memory with an array
+    task load(input data_t data[]);
+        foreach (data[i]) memory[i] = data[i];
+    endtask
 
-// Write function (bypasses the run function)
-function void write(addr_t address, data_t data);
-    if (address < (1 << ADDR_BITS)) begin
-        memory[address] = data;
-    end
-endfunction
-
-// Load function
-task load(input data_t data[]);
-    foreach (data[i]) begin
-        memory[i] = data[i];
-    end
-endtask
-
-// Display function:
-// TODO: revisit after logger function is implemented
-// Displays memory contents in a readable format
-task display(int rows = 16);
-    $display("\n=== %s MEMORY DUMP ===", name);
-    for (int i = 0; i < rows; i++) begin
-        $display("Addr %0d: 0x%0h", i, memory[i]);
-    end
-    $display("========================\n");
-endtask
+    // Display memory contents
+    task display(int rows = 16);
+        $display("\n=== %s MEMORY DUMP ===", name);
+        for (int i = 0; i < rows; i++) begin
+            $display("Addr %0d: 0x%0h", i, memory[i]);
+        end
+        $display("========================\n");
+    endtask
 endclass

--- a/test/helpers/memoryif.sv
+++ b/test/helpers/memoryif.sv
@@ -1,0 +1,26 @@
+interface mem_if #(
+    parameter int ADDR_BITS = 8,
+    parameter int DATA_BITS = 16,
+    parameter int CHANNELS  = 1
+);
+    logic [CHANNELS-1:0]         read_valid;
+    logic [ADDR_BITS-1:0]        read_address [CHANNELS];
+    logic [DATA_BITS-1:0]        read_data    [CHANNELS];
+    logic [CHANNELS-1:0]         read_ready;
+
+    logic [CHANNELS-1:0]         write_valid;
+    logic [ADDR_BITS-1:0]        write_address [CHANNELS];
+    logic [DATA_BITS-1:0]        write_data    [CHANNELS];
+    logic [CHANNELS-1:0]         write_ready;
+
+    modport ro (
+        input  read_valid, read_address,
+        output read_data, read_ready
+    );
+
+    modport rw (
+        input  read_valid, read_address,
+               write_valid, write_address, write_data,
+        output read_data, read_ready, write_ready
+    );
+endinterface

--- a/test/test_matadd.sv
+++ b/test/test_matadd.sv
@@ -1,5 +1,6 @@
 `include "helpers/memory.sv"
 // `include "helpers/setup.sv"
+`timescale 1ns/1ns
 
 module test_matadd;
     localparam DATA_MEM_ADDR_BITS     = 8;
@@ -25,17 +26,17 @@ module test_matadd;
     always #5 clk = ~clk;
 
     // Instantiate memory interfaces
-    virtual mem_if #(
+    mem_if #(
         .ADDR_BITS(PROGRAM_MEM_ADDR_BITS),
         .DATA_BITS(PROGRAM_MEM_DATA_BITS),
         .CHANNELS(PROGRAM_MEM_CHANNELS)
-    ) program_mem_if;
+    ) program_mem_if();
 
-    virtual mem_if #(
+    mem_if #(
         .ADDR_BITS(DATA_MEM_ADDR_BITS),
         .DATA_BITS(DATA_MEM_DATA_BITS),
         .CHANNELS(DATA_MEM_CHANNELS)
-    ) data_mem_if;
+    ) data_mem_if();
 
 
     // Program Memory

--- a/test/test_matadd.sv
+++ b/test/test_matadd.sv
@@ -20,28 +20,25 @@ module test_matadd;
     logic device_control_write_enable;
     logic [7:0] device_control_data;
 
-    // Program Memory interface signals
-    logic program_mem_read_valid;
-    logic [PROGRAM_MEM_ADDR_BITS-1:0] program_mem_read_address;
-    logic program_mem_read_ready;
-    logic [PROGRAM_MEM_DATA_BITS-1:0] program_mem_read_data;
-
-    // Data Memory interface signals
-    logic [DATA_MEM_CHANNELS-1:0] data_mem_read_valid;
-    logic [DATA_MEM_ADDR_BITS-1:0] data_mem_read_address [DATA_MEM_CHANNELS-1:0];
-    logic [DATA_MEM_CHANNELS-1:0] data_mem_read_ready;
-    logic [DATA_MEM_DATA_BITS-1:0] data_mem_read_data [DATA_MEM_CHANNELS-1:0];
-    logic [DATA_MEM_CHANNELS-1:0] data_mem_write_valid;
-    logic [DATA_MEM_ADDR_BITS-1:0] data_mem_write_address [DATA_MEM_CHANNELS-1:0];
-    logic [DATA_MEM_DATA_BITS-1:0] data_mem_write_data    [DATA_MEM_CHANNELS-1:0];
-    logic [DATA_MEM_CHANNELS-1:0] data_mem_write_ready;
-
-
     // Clock generation
     initial clk = 0;
     always #5 clk = ~clk;
 
-    // Instantiate Program Memory
+    // Instantiate memory interfaces
+    virtual mem_if #(
+        .ADDR_BITS(PROGRAM_MEM_ADDR_BITS),
+        .DATA_BITS(PROGRAM_MEM_DATA_BITS),
+        .CHANNELS(PROGRAM_MEM_CHANNELS)
+    ) program_mem_if;
+
+    virtual mem_if #(
+        .ADDR_BITS(DATA_MEM_ADDR_BITS),
+        .DATA_BITS(DATA_MEM_DATA_BITS),
+        .CHANNELS(DATA_MEM_CHANNELS)
+    ) data_mem_if;
+
+
+    // Program Memory
     Memory #(
         .ADDR_BITS(PROGRAM_MEM_ADDR_BITS),
         .DATA_BITS(PROGRAM_MEM_DATA_BITS),
@@ -64,7 +61,7 @@ module test_matadd;
         16'b1111000000000000
     };
 
-    // Instantiate Data Memory
+    // Data Memory
     Memory #(
         .ADDR_BITS(DATA_MEM_ADDR_BITS),
         .DATA_BITS(DATA_MEM_DATA_BITS),

--- a/test/test_matadd.sv
+++ b/test/test_matadd.sv
@@ -122,23 +122,9 @@ module test_matadd;
         // data_memory    = new("data");
 
         // Hook interface signals to class instances
-        program_memory = new("program",
-            program_mem_read_valid,
-            program_mem_read_address,
-            program_mem_read_ready,
-            program_mem_read_data
-        );
+        program_memory = new("program", program_mem_if);
 
-        data_memory = new("data",
-            data_mem_read_valid,
-            data_mem_read_address,
-            data_mem_read_ready,
-            data_mem_read_data,
-            data_mem_write_valid,
-            data_mem_write_address,
-            data_mem_write_data,
-            data_mem_write_ready
-        );
+        data_memory = new("data", data_mem_if);
 
         // Load program and data memory
         program_memory.load(prog);

--- a/test/test_matadd.sv
+++ b/test/test_matadd.sv
@@ -23,7 +23,7 @@ module test_matadd;
 
     // Clock generation
     initial clk = 0;
-    always #5 clk = ~clk;
+    always #25000 clk = ~clk;
 
     // Instantiate memory interfaces
     mem_if #(
@@ -111,12 +111,18 @@ module test_matadd;
         .data_mem_write_ready(data_mem_if.write_ready)
     );
 
+    always @(posedge clk) begin
+ 	$display("T=%0t | reset=%b start=%b done=%b", $time, reset, start, done);
+    	$display("T=%0t | reset=%b start=%b done=%b | ctrl_we=%b ctrl_data=%0d", 
+              $time, reset, start, done, device_control_write_enable, device_control_data);
+    end
+
     initial begin
         cycles = 0;
         // Setup and reset
-        reset = 0;
-        @(posedge clk);
         reset = 1;
+        @(posedge clk);
+        reset = 0;
 
         // // Construct memories
         // program_memory = new("program");
@@ -140,7 +146,7 @@ module test_matadd;
         // Start DUT
         start = 1'b1;
         @(posedge clk);
-        start = 1'b0;
+        // start = 1'b0;
 
         while (done !== 1) begin
             program_memory.run();

--- a/test/test_matadd.sv
+++ b/test/test_matadd.sv
@@ -93,19 +93,21 @@ module test_matadd;
         .device_control_write_enable(device_control_write_enable),
         .device_control_data(device_control_data),
 
-        .program_mem_read_valid(program_mem_read_valid),
-        .program_mem_read_address(program_mem_read_address),
-        .program_mem_read_ready(program_mem_read_ready),
-        .program_mem_read_data(program_mem_read_data),
+        // Program memory hookup via interface
+        .program_mem_read_valid(program_mem_if.read_valid),
+        .program_mem_read_address(program_mem_if.read_address),
+        .program_mem_read_ready(program_mem_if.read_ready),
+        .program_mem_read_data(program_mem_if.read_data),
 
-        .data_mem_read_valid(data_mem_read_valid),
-        .data_mem_read_address(data_mem_read_address),
-        .data_mem_read_ready(data_mem_read_ready),
-        .data_mem_read_data(data_mem_read_data),
-        .data_mem_write_valid(data_mem_write_valid),
-        .data_mem_write_address(data_mem_write_address),
-        .data_mem_write_data(data_mem_write_data),
-        .data_mem_write_ready(data_mem_write_ready)
+        // Data memory hookup via interface
+        .data_mem_read_valid(data_mem_if.read_valid),
+        .data_mem_read_address(data_mem_if.read_address),
+        .data_mem_read_ready(data_mem_if.read_ready),
+        .data_mem_read_data(data_mem_if.read_data),
+        .data_mem_write_valid(data_mem_if.write_valid),
+        .data_mem_write_address(data_mem_if.write_address),
+        .data_mem_write_data(data_mem_if.write_data),
+        .data_mem_write_ready(data_mem_if.write_ready)
     );
 
     initial begin


### PR DESCRIPTION
Implementing the interface also allowed a full port of the test_matadd.py file to an equivalent SystemVerilog testbench module.